### PR TITLE
⬆️ Downgrades Deluge to v2.0.3-3.1

### DIFF
--- a/deluge/Dockerfile
+++ b/deluge/Dockerfile
@@ -16,13 +16,13 @@ RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         gnupg=2.2.27-2 \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C \
-    && echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu hirsute main" >> \
-        /etc/apt/sources.list.d/deluge.list \
-    && echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu hirsute main" >> \
-        /etc/apt/sources.list.d/deluge.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
+    # && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C \
+    # && echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu hirsute main" >> \
+    #     /etc/apt/sources.list.d/deluge.list \
+    # && echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu hirsute main" >> \
+    #     /etc/apt/sources.list.d/deluge.list \
+    # && apt-get update \
+    # && apt-get install -y --no-install-recommends \
         deluge-common=${RELEASE} \
         deluged=${RELEASE} \
         deluge-console=${RELEASE} \

--- a/deluge/build.yaml
+++ b/deluge/build.yaml
@@ -5,4 +5,4 @@ build_from:
   armv7: ghcr.io/hassio-addons/debian-base/armv7:5.2.2
   i386: ghcr.io/hassio-addons/debian-base/i386:5.2.2
 args:
-  release: 2.0.4-0~202112121857~ubuntu21.04.1
+  release: 2.0.3-3.1


### PR DESCRIPTION
There is an error with deluge-web v2.0.4

Downgrades Deluge to v2.0.3-3.1